### PR TITLE
Bridge RACSignal lightweight generics from ReactiveObjC 2.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "ReactiveCocoa/ReactiveObjC" "e932b77d2637a424b201a2dd7ce2f88584794e29"
+github "ReactiveCocoa/ReactiveObjC" ~> 2.1
 github "ReactiveCocoa/ReactiveSwift" "1.0.0-alpha.3"

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "ReactiveCocoa/ReactiveObjC" ~> 1.0
+github "ReactiveCocoa/ReactiveObjC" ~> 2.0
 github "ReactiveCocoa/ReactiveSwift" "1.0.0-alpha.3"

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "ReactiveCocoa/ReactiveObjC" ~> 2.0
+github "ReactiveCocoa/ReactiveObjC" "e932b77d2637a424b201a2dd7ce2f88584794e29"
 github "ReactiveCocoa/ReactiveSwift" "1.0.0-alpha.3"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 github "Quick/Nimble" "v5.1.1"
 github "Quick/Quick" "v0.10.0"
-github "ReactiveCocoa/ReactiveObjC" "2.0.0"
+github "ReactiveCocoa/ReactiveObjC" "e932b77d2637a424b201a2dd7ce2f88584794e29"
 github "antitypical/Result" "3.0.0"
 github "jspahrsummers/xcconfigs" "3d9d99634cae6d586e272543d527681283b33eb0"
 github "ReactiveCocoa/ReactiveSwift" "1.0.0-alpha.3"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 github "Quick/Nimble" "v5.1.1"
 github "Quick/Quick" "v0.10.0"
-github "ReactiveCocoa/ReactiveObjC" "e932b77d2637a424b201a2dd7ce2f88584794e29"
+github "ReactiveCocoa/ReactiveObjC" "2.1.0"
 github "antitypical/Result" "3.0.0"
 github "jspahrsummers/xcconfigs" "3d9d99634cae6d586e272543d527681283b33eb0"
 github "ReactiveCocoa/ReactiveSwift" "1.0.0-alpha.3"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
-github "Quick/Nimble" "v5.0.0"
+github "Quick/Nimble" "v5.1.1"
 github "Quick/Quick" "v0.10.0"
-github "ReactiveCocoa/ReactiveObjC" "1.0.1"
+github "ReactiveCocoa/ReactiveObjC" "2.0.0"
 github "antitypical/Result" "3.0.0"
 github "jspahrsummers/xcconfigs" "3d9d99634cae6d586e272543d527681283b33eb0"
 github "ReactiveCocoa/ReactiveSwift" "1.0.0-alpha.3"

--- a/ReactiveObjCBridge/ObjectiveCBridging.swift
+++ b/ReactiveObjCBridge/ObjectiveCBridging.swift
@@ -119,7 +119,7 @@ private func defaultNSError(_ message: String, file: String, line: Int) -> NSErr
 ///   - line: Current line in file.
 ///
 /// - returns: Signal producer created from the provided signal.
-public func signalProducer<Value>(from signal: RACSignal<Value>, file: String = #file, line: Int = #line) -> SignalProducer<Value?, NSError> {
+public func bridgedSignalProducer<Value>(from signal: RACSignal<Value>, file: String = #file, line: Int = #line) -> SignalProducer<Value?, NSError> {
 	return SignalProducer<Value?, NSError> { observer, disposable in
 		let next: (_ value: Value?) -> Void = { obj in
 			observer.send(value: obj)
@@ -282,14 +282,14 @@ extension ActionProtocol {
 public func bridgedAction<Input, Output>(from command: RACCommand<Input, Output>, file: String = #file, line: Int = #line) -> Action<Input?, Output?, NSError> {
 	let enabledProperty = MutableProperty(true)
 
-	enabledProperty <~ signalProducer(from: command.enabled)
+	enabledProperty <~ bridgedSignalProducer(from: command.enabled)
 		.map { $0 as! Bool }
 		.flatMapError { _ in SignalProducer<Bool, NoError>(value: false) }
 
 	return Action<Input?, Output?, NSError>(enabledIf: enabledProperty) { input -> SignalProducer<Output?, NSError> in
 		let signal: RACSignal<Output> = command.execute(input)
 
-		return signalProducer(from: signal)
+		return bridgedSignalProducer(from: signal)
 	}
 }
 

--- a/ReactiveObjCBridge/ObjectiveCBridging.swift
+++ b/ReactiveObjCBridge/ObjectiveCBridging.swift
@@ -44,7 +44,7 @@ extension RACScheduler: DateSchedulerProtocol {
 	///            begins.
 	@discardableResult
 	public func schedule(_ action: @escaping () -> Void) -> Disposable? {
-		let disposable: RACDisposable = self.schedule(action) // Call the Objective-C implementation
+		let disposable: RACDisposable? = self.schedule(action) // Call the Objective-C implementation
 		return disposable as Disposable?
 	}
 

--- a/ReactiveObjCBridge/ObjectiveCBridging.swift
+++ b/ReactiveObjCBridge/ObjectiveCBridging.swift
@@ -110,43 +110,42 @@ private func defaultNSError(_ message: String, file: String, line: Int) -> NSErr
 	return Result<(), NSError>.error(message, file: file, line: line)
 }
 
-extension RACSignal {
-	/// Create a `SignalProducer` which will subscribe to the receiver once for
-	/// each invocation of `start()`.
-	///
-	/// - parameters:
-	///   - file: Current file name.
-	///   - line: Current line in file.
-	///
-	/// - returns: Signal producer created from `self`.
-	public func toSignalProducer(file: String = #file, line: Int = #line) -> SignalProducer<Any?, NSError> {
-		return SignalProducer { observer, disposable in
-			let next = { obj in
-				observer.send(value: obj)
-			}
-
-			let failed: (_ nsError: Swift.Error?) -> () = {
-				observer.send(error: ($0 as? NSError) ?? defaultNSError("Nil RACSignal error", file: file, line: line))
-			}
-
-			let completed = {
-				observer.sendCompleted()
-			}
-
-			disposable += self.subscribeNext(next, error: failed, completed: completed)
+/// Create a `SignalProducer` which will subscribe to the provided signal once
+/// for each invocation of `start()`.
+///
+/// - parameters:
+///   - signal: The signal to bridge to a signal producer.
+///   - file: Current file name.
+///   - line: Current line in file.
+///
+/// - returns: Signal producer created from the provided signal.
+public func signalProducer<Value>(from signal: RACSignal<Value>, file: String = #file, line: Int = #line) -> SignalProducer<Value?, NSError> {
+	return SignalProducer<Value?, NSError> { observer, disposable in
+		let next: (_ value: Value?) -> Void = { obj in
+			observer.send(value: obj)
 		}
+
+		let failed: (_ nsError: Swift.Error?) -> () = {
+			observer.send(error: ($0 as? NSError) ?? defaultNSError("Nil RACSignal error", file: file, line: line))
+		}
+
+		let completed = {
+			observer.sendCompleted()
+		}
+
+		disposable += signal.subscribeNext(next, error: failed, completed: completed)
 	}
 }
 
-extension SignalProducerProtocol {
+extension SignalProducerProtocol where Value: AnyObject {
 	/// Create a `RACSignal` that will `start()` the producer once for each
 	/// subscription.
 	///
 	/// - note: Any `interrupted` events will be silently discarded.
 	///
 	/// - returns: `RACSignal` instantiated from `self`.
-	public func toRACSignal() -> RACSignal {
-		return RACSignal.createSignal { subscriber in
+	public func toRACSignal() -> RACSignal<Value> {
+		return RACSignal<Value>.createSignal { subscriber in
 			let selfDisposable = self.start { event in
 				switch event {
 				case let .value(value):
@@ -199,14 +198,14 @@ extension SignalProducerProtocol where Self.Value: OptionalProtocol {
 	}
 }
 
-extension SignalProtocol {
+extension SignalProtocol where Value: AnyObject {
 	/// Create a `RACSignal` that will observe the given signal.
 	///
 	/// - note: Any `interrupted` events will be silently discarded.
 	///
 	/// - returns: `RACSignal` instantiated from `self`.
-	public func toRACSignal() -> RACSignal {
-		return RACSignal.createSignal { subscriber in
+	public func toRACSignal() -> RACSignal<Value> {
+		return RACSignal<Value>.createSignal { subscriber in
 			let selfDisposable = self.observe { event in
 				switch event {
 				case let .value(value):
@@ -260,37 +259,8 @@ extension SignalProtocol where Self.Value: OptionalProtocol {
 
 // MARK: -
 
-// FIXME: Reintroduce `RACCommand.toAction` when compiler no longer segfault
-//        on extensions to parameterized ObjC classes.
-/**
-extension RACCommand {
-	/// Creates an Action that will execute the receiver.
-	///
-	/// - note: The returned Action will not necessarily be marked as executing
-	///         when the command is. However, the reverse is always true: the
-	///         RACCommand will always be marked as executing when the action
-	///         is.
-	///
-	/// - parameters:
-	///   - file: Current file name.
-	///   - line: Current line in file.
-	///
-	/// - returns: Action created from `self`.
-	public func toAction(file: String = #file, line: Int = #line) -> Action<Any?, Any?, NSError> {
-		let enabledProperty = MutableProperty(true)
-
-		enabledProperty <~ self.enabled.toSignalProducer()
-			.map { $0 as! Bool }
-			.flatMapError { _ in SignalProducer<Bool, NoError>(value: false) }
-
-		return Action(enabledIf: enabledProperty) { input -> SignalProducer<Any?, NSError> in
-			let executionSignal = RACSignal.`defer` {
-				return self.execute(input)
-			}
-**/
-
 extension ActionProtocol {
-	fileprivate var isCommandEnabled: RACSignal {
+	fileprivate var isCommandEnabled: RACSignal<NSNumber> {
 		return self.isEnabled.producer
 			.map { $0 as NSNumber }
 			.toRACSignal()
@@ -309,24 +279,21 @@ extension ActionProtocol {
 ///   - line: Current line in file.
 ///
 /// - returns: Action created from `self`.
-public func bridgedAction<Input>(from command: RACCommand<Input>, file: String = #file, line: Int = #line) -> Action<Any?, Any?, NSError> {
-	let command = command as! RACCommand<AnyObject>
+public func bridgedAction<Input, Output>(from command: RACCommand<Input, Output>, file: String = #file, line: Int = #line) -> Action<Input?, Output?, NSError> {
 	let enabledProperty = MutableProperty(true)
 
-	enabledProperty <~ command.enabled.toSignalProducer()
+	enabledProperty <~ signalProducer(from: command.enabled)
 		.map { $0 as! Bool }
 		.flatMapError { _ in SignalProducer<Bool, NoError>(value: false) }
 
-	return Action(enabledIf: enabledProperty) { input -> SignalProducer<Any?, NSError> in
-		let executionSignal = RACSignal.`defer` {
-			return command.execute(input as AnyObject?)
-		}
+	return Action<Input?, Output?, NSError>(enabledIf: enabledProperty) { input -> SignalProducer<Output?, NSError> in
+		let signal: RACSignal<Output> = command.execute(input)
 
-		return executionSignal.toSignalProducer(file: file, line: line)
+		return signalProducer(from: signal)
 	}
 }
 
-extension ActionProtocol where Input: AnyObject {
+extension ActionProtocol where Input: AnyObject, Output: AnyObject {
 	/// Creates a RACCommand that will execute the action.
 	///
 	/// - note: The returned command will not necessarily be marked as executing
@@ -334,16 +301,15 @@ extension ActionProtocol where Input: AnyObject {
 	///         will always be marked as executing when the RACCommand is.
 	///
 	/// - returns: `RACCommand` with bound action.
-	public func toRACCommand() -> RACCommand<Input> {
-		return RACCommand<Input>(enabled: action.isCommandEnabled) { input -> RACSignal in
-			return self
-				.apply(input!)
+	public func toRACCommand() -> RACCommand<Input, Output> {
+		return RACCommand<Input, Output>(enabled: action.isCommandEnabled) { input -> RACSignal<Output> in
+			return self.apply(input!)
 				.toRACSignal()
 		}
 	}
 }
 
-extension ActionProtocol where Input: OptionalProtocol, Input.Wrapped: AnyObject {
+extension ActionProtocol where Input: OptionalProtocol, Input.Wrapped: AnyObject, Output: AnyObject {
 	/// Creates a RACCommand that will execute the action.
 	///
 	/// - note: The returned command will not necessarily be marked as executing
@@ -351,8 +317,8 @@ extension ActionProtocol where Input: OptionalProtocol, Input.Wrapped: AnyObject
 	///         will always be marked as executing when the RACCommand is.
 	///
 	/// - returns: `RACCommand` with bound action.
-	public func toRACCommand() -> RACCommand<Input.Wrapped> {
-		return RACCommand<Input.Wrapped>(enabled: action.isCommandEnabled) { input -> RACSignal in
+	public func toRACCommand() -> RACCommand<Input.Wrapped, Output> {
+		return RACCommand<Input.Wrapped, Output>(enabled: action.isCommandEnabled) { input -> RACSignal<Output> in
 			return self
 				.apply(Input(reconstructing: input))
 				.toRACSignal()

--- a/ReactiveObjCBridgeTests/ObjectiveCBridgingSpec.swift
+++ b/ReactiveObjCBridgeTests/ObjectiveCBridgingSpec.swift
@@ -70,7 +70,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					return nil
 				}
 
-				let producer = signalProducer(from: racSignal).map { $0 as! Int }
+				let producer = bridgedSignalProducer(from: racSignal).map { $0 as! Int }
 
 				expect((producer.single())?.value) == 0
 				expect((producer.single())?.value) == 1
@@ -81,7 +81,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 				let error = TestError.default as NSError
 
 				let racSignal = RACSignal<AnyObject>.error(error)
-				let producer = signalProducer(from: racSignal)
+				let producer = bridgedSignalProducer(from: racSignal)
 				let result = producer.last()
 
 				expect(result?.error) == error
@@ -231,8 +231,8 @@ class ObjectiveCBridgingSpec: QuickSpec {
 				command.enabled.subscribeNext { enabled = $0 as! Bool }
 				expect(enabled) == true
 
-				let values = signalProducer(from: command.executionSignals)
-					.map { signalProducer(from: $0!) }
+				let values = bridgedSignalProducer(from: command.executionSignals)
+					.map { bridgedSignalProducer(from: $0!) }
 					.flatten(.concat)
 
 				values.startWithResult { results.append($0.value as! Int) }

--- a/ReactiveObjCBridgeTests/ObjectiveCBridgingSpec.swift
+++ b/ReactiveObjCBridgeTests/ObjectiveCBridgingSpec.swift
@@ -151,10 +151,13 @@ class ObjectiveCBridgingSpec: QuickSpec {
 				}
 				
 				it("should bridge next events with value Optional<Any>.none to nil in Objective-C") {
-					let producer = SignalProducer<Optional<Any>, NSError>(value: nil)
-					let racSignal = producer.toRACSignal().materialize()
+					let (signal, observer) = Signal<Optional<AnyObject>, NSError>.pipe()
+					let racSignal = signal.toRACSignal().replay().materialize()
+
+					observer.send(value: nil)
+					observer.sendCompleted()
 					
-					let event = racSignal.first() as? RACEvent
+					let event = racSignal.first()
 					expect(event?.value).to(beNil())
 				}
 			}
@@ -194,11 +197,11 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					expect(userInfoValue) == userInfo[key]
 				}
 				
-				it("should bridge next events with value Optional<Any>.none to nil in Objective-C") {
-					let producer = SignalProducer<Optional<Any>, NSError>(value: nil)
+				it("should bridge next events with value Optional<AnyObject>.none to nil in Objective-C") {
+					let producer = SignalProducer<Optional<AnyObject>, NSError>(value: nil)
 					let racSignal = producer.toRACSignal().materialize()
 					
-					let event = racSignal.first() as? RACEvent
+					let event = racSignal.first()
 					expect(event?.value).to(beNil())
 				}
 			}
@@ -271,12 +274,12 @@ class ObjectiveCBridgingSpec: QuickSpec {
 		}
 
 		describe("toRACCommand") {
-			var action: Action<AnyObject?, NSString, TestError>!
+			var action: Action<NSNumber, NSString, TestError>!
 			var results: [NSString] = []
 
 			var enabledProperty: MutableProperty<Bool>!
 
-			var command: RACCommand<AnyObject, NSString>!
+			var command: RACCommand<NSNumber, NSString>!
 			var enabled = false
 			
 			beforeEach {
@@ -284,7 +287,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 				enabledProperty = MutableProperty(true)
 
 				action = Action(enabledIf: enabledProperty) { input in
-					let inputNumber = input as! Int
+					let inputNumber = input as Int
 					return SignalProducer(value: "\(inputNumber + 1)" as NSString)
 				}
 
@@ -308,7 +311,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 			}
 
 			it("should apply and start a signal once per execution") {
-				let signal = command.execute(0 as NSNumber)
+				let signal = command.execute(0)
 
 				do {
 					try signal.asynchronouslyWaitUntilCompleted()
@@ -323,19 +326,83 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					XCTFail("Failed to wait for completion")
 				}
 			}
+
+			it("should bridge both inputs and ouputs with Optional<AnyObject>.none to nil in Objective-C") {
+				var action: Action<Optional<AnyObject>, Optional<AnyObject>, TestError>!
+				var command: RACCommand<AnyObject, AnyObject>!
+
+				action = Action() { input in
+					return SignalProducer(value: input)
+				}
+
+				command = action.toRACCommand()
+				expect(command).notTo(beNil())
+
+				let racSignal = command.executionSignals.flatten().materialize().replay()
+
+				command.execute(Optional<AnyObject>.none)
+
+				let event = try! racSignal.asynchronousFirstOrDefault(nil, success: nil)
+				expect(event.value).to(beNil())
+			}
+
+			it("should bridge outputs with Optional<AnyObject>.none to nil in Objective-C") {
+				var action: Action<NSString, Optional<AnyObject>, TestError>!
+				var command: RACCommand<NSString, AnyObject>!
+
+				action = Action() { input in
+					return SignalProducer(value: Optional<AnyObject>.none)
+				}
+
+				command = action.toRACCommand()
+				expect(command).notTo(beNil())
+
+				let racSignal = command.executionSignals.flatten().materialize().replay()
+
+				command.execute("input" as NSString)
+
+				let event = try! racSignal.asynchronousFirstOrDefault(nil, success: nil)
+				expect(event.value).to(beNil())
+			}
+
+			it("should bridge inputs with Optional<AnyObject>.none to nil in Objective-C") {
+				var action: Action<Optional<AnyObject>, NSString, TestError>!
+				var command: RACCommand<AnyObject, NSString>!
+
+				let enabledSubject = RACSubject()
+
+				let enabledSignal = RACSignal<NSNumber>
+					.createSignal({ subscriber in
+						return enabledSubject.subscribe(subscriber)
+					})
+					.replay()
+					.materialize()
+
+				action = Action() { input in
+					enabledSubject.sendNext(input)
+					return SignalProducer(value: "result")
+				}
+
+				command = action.toRACCommand()
+				expect(command).notTo(beNil())
+
+				command.execute(Optional<AnyObject>.none)
+
+				let event = try! enabledSignal.asynchronousFirstOrDefault(nil, success: nil)
+				expect(event.value).to(beNil())
+			}
 		}
 		
 		describe("RACSubscriber.sendNext") {
-			
 			it("should have an argument of type Optional.none represented as `nil`") {
-				let racSignal = RACSignal.createSignal { subscriber in
-					subscriber.sendNext(Optional<Any>.none)
+				let racSignal = RACSignal<AnyObject>.createSignal { subscriber in
+					subscriber.sendNext(Optional<AnyObject>.none)
 					subscriber.sendCompleted()
 					return nil
 				}
 				
-				let event = racSignal.first() as? RACEvent
-				let value = event?.value
+				let event = try! racSignal.materialize().asynchronousFirstOrDefault(nil, success: nil)
+				let value = event.value
 				expect(value).to(beNil())
 			}
 		}

--- a/ReactiveObjCBridgeTests/ObjectiveCBridgingSpec.swift
+++ b/ReactiveObjCBridgeTests/ObjectiveCBridgingSpec.swift
@@ -369,17 +369,17 @@ class ObjectiveCBridgingSpec: QuickSpec {
 				var action: Action<Optional<AnyObject>, NSString, TestError>!
 				var command: RACCommand<AnyObject, NSString>!
 
-				let enabledSubject = RACSubject()
+				let inputSubject = RACSubject()
 
-				let enabledSignal = RACSignal<NSNumber>
+				let inputSignal = RACSignal<NSNumber>
 					.createSignal({ subscriber in
-						return enabledSubject.subscribe(subscriber)
+						return inputSubject.subscribe(subscriber)
 					})
 					.replay()
 					.materialize()
 
 				action = Action() { input in
-					enabledSubject.sendNext(input)
+					inputSubject.sendNext(input)
 					return SignalProducer(value: "result")
 				}
 
@@ -388,7 +388,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 
 				command.execute(Optional<AnyObject>.none)
 
-				let event = try! enabledSignal.asynchronousFirstOrDefault(nil, success: nil)
+				let event = try! inputSignal.asynchronousFirstOrDefault(nil, success: nil)
 				expect(event.value).to(beNil())
 			}
 		}

--- a/ReactiveObjCBridgeTests/ObjectiveCBridgingSpec.swift
+++ b/ReactiveObjCBridgeTests/ObjectiveCBridgingSpec.swift
@@ -172,16 +172,16 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					}
 					let racSignal = producer.toRACSignal()
 
-					expect(racSignal.first() as? NSNumber) == 0
-					expect(racSignal.first() as? NSNumber) == 1
-					expect(racSignal.first() as? NSNumber) == 2
+					expect(racSignal.first()) == 0
+					expect(racSignal.first()) == 1
+					expect(racSignal.first()) == 2
 				}
 
 				it("should convert errors to NSError") {
 					let producer = SignalProducer<AnyObject, TestError>(error: .error1)
 					let racSignal = producer.toRACSignal().materialize()
 
-					let event = racSignal.first() as? RACEvent
+					let event = racSignal.first()
 					expect(event?.error as? NSError) == TestError.error1 as NSError
 				}
 				
@@ -189,7 +189,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					let producer = SignalProducer<AnyObject, NSError>(error: testNSError)
 					let racSignal = producer.toRACSignal().materialize()
 					
-					let event = racSignal.first() as? RACEvent
+					let event = racSignal.first()
 					let userInfoValue = event?.error?.localizedDescription
 					expect(userInfoValue) == userInfo[key]
 				}

--- a/ReactiveObjCBridgeTests/ObjectiveCBridgingSpec.swift
+++ b/ReactiveObjCBridgeTests/ObjectiveCBridgingSpec.swift
@@ -225,8 +225,8 @@ class ObjectiveCBridgingSpec: QuickSpec {
 				})
 
 				command = RACCommand<NSNumber, NSNumber>(enabled: enabledSignal) { input in
-					let inputNumber = input as! Int
-					return RACSignal<NSNumber>.`return`(inputNumber + 1)
+					let inputNumber = input as! Int + 1
+					return RACSignal<NSNumber>.`return`(inputNumber as NSNumber)
 				}
 
 				expect(command).notTo(beNil())


### PR DESCRIPTION
This should substantially improve bridging to existing `ReactiveObjC` code, as `RACSignal` ValueType information can now be bridged as well.

Note: This is breaking change, since a free function must be used in place of an extension. When you attempt to use the current pattern of adding extensions to `RACSignal` to expose bridging methods, you encounter the following issue:

```
Extension of a generic Objective-C class cannot access the class's generic parameters at runtime
```

This is the same reason why `RACCommand` does not follow this pattern currently.