### PR TITLE
Improve bridging experience.

### DIFF
--- a/ReactiveObjCBridge.xcodeproj/project.pbxproj
+++ b/ReactiveObjCBridge.xcodeproj/project.pbxproj
@@ -16,6 +16,14 @@
 		7DFBED201CDB8D7D00EE435B /* Nimble.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D05E662419EDD82000904ACA /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7DFBED211CDB8D8300EE435B /* Result.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = CDC42E2E1AE7AB8B00965373 /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7DFBED271CDB8DE300EE435B /* ObjectiveCBridgingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A226101A72F30B00D33B74 /* ObjectiveCBridgingSpec.swift */; };
+		9AB5CD651EDAC351004ECB57 /* RACScheduler+SwiftSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AB5CD631EDAC351004ECB57 /* RACScheduler+SwiftSupport.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9AB5CD661EDAC351004ECB57 /* RACScheduler+SwiftSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AB5CD631EDAC351004ECB57 /* RACScheduler+SwiftSupport.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9AB5CD671EDAC351004ECB57 /* RACScheduler+SwiftSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AB5CD631EDAC351004ECB57 /* RACScheduler+SwiftSupport.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9AB5CD681EDAC351004ECB57 /* RACScheduler+SwiftSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AB5CD631EDAC351004ECB57 /* RACScheduler+SwiftSupport.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9AB5CD691EDAC351004ECB57 /* RACScheduler+SwiftSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 9AB5CD641EDAC351004ECB57 /* RACScheduler+SwiftSupport.m */; };
+		9AB5CD6A1EDAC351004ECB57 /* RACScheduler+SwiftSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 9AB5CD641EDAC351004ECB57 /* RACScheduler+SwiftSupport.m */; };
+		9AB5CD6B1EDAC351004ECB57 /* RACScheduler+SwiftSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 9AB5CD641EDAC351004ECB57 /* RACScheduler+SwiftSupport.m */; };
+		9AB5CD6C1EDAC351004ECB57 /* RACScheduler+SwiftSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 9AB5CD641EDAC351004ECB57 /* RACScheduler+SwiftSupport.m */; };
 		A9B315BF1B3940810001CB9C /* ObjectiveCBridging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312C419EF2A5800984962 /* ObjectiveCBridging.swift */; };
 		A9B315C91B3940980001CB9C /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC42E2E1AE7AB8B00965373 /* Result.framework */; };
 		A9B315CA1B3940AB0001CB9C /* ReactiveObjCBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = D04725EF19E49ED7006002AA /* ReactiveObjCBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -121,6 +129,8 @@
 		57A4D2461BA13F9700F7D4B1 /* tvOS-Framework.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-Framework.xcconfig"; sourceTree = "<group>"; };
 		57A4D2471BA13F9700F7D4B1 /* tvOS-StaticLibrary.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-StaticLibrary.xcconfig"; sourceTree = "<group>"; };
 		7DFBED031CDB8C9500EE435B /* ReactiveObjCBridgeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReactiveObjCBridgeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9AB5CD631EDAC351004ECB57 /* RACScheduler+SwiftSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RACScheduler+SwiftSupport.h"; sourceTree = "<group>"; };
+		9AB5CD641EDAC351004ECB57 /* RACScheduler+SwiftSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RACScheduler+SwiftSupport.m"; sourceTree = "<group>"; };
 		A97451331B3A935E00F48E55 /* watchOS-Application.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "watchOS-Application.xcconfig"; sourceTree = "<group>"; };
 		A97451341B3A935E00F48E55 /* watchOS-Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "watchOS-Base.xcconfig"; sourceTree = "<group>"; };
 		A97451351B3A935E00F48E55 /* watchOS-Framework.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "watchOS-Framework.xcconfig"; sourceTree = "<group>"; };
@@ -328,6 +338,8 @@
 			children = (
 				D04725EF19E49ED7006002AA /* ReactiveObjCBridge.h */,
 				D0C312C419EF2A5800984962 /* ObjectiveCBridging.swift */,
+				9AB5CD631EDAC351004ECB57 /* RACScheduler+SwiftSupport.h */,
+				9AB5CD641EDAC351004ECB57 /* RACScheduler+SwiftSupport.m */,
 				D04725ED19E49ED7006002AA /* Supporting Files */,
 			);
 			path = ReactiveObjCBridge;
@@ -437,6 +449,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9AB5CD681EDAC351004ECB57 /* RACScheduler+SwiftSupport.h in Headers */,
 				57A4D20A1BA13D7A00F7D4B1 /* ReactiveObjCBridge.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -445,6 +458,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9AB5CD671EDAC351004ECB57 /* RACScheduler+SwiftSupport.h in Headers */,
 				A9B315CA1B3940AB0001CB9C /* ReactiveObjCBridge.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -453,6 +467,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9AB5CD651EDAC351004ECB57 /* RACScheduler+SwiftSupport.h in Headers */,
 				D04725F019E49ED7006002AA /* ReactiveObjCBridge.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -461,6 +476,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9AB5CD661EDAC351004ECB57 /* RACScheduler+SwiftSupport.h in Headers */,
 				D037666419EDA43C00A782A9 /* ReactiveObjCBridge.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -607,7 +623,7 @@
 				ORGANIZATIONNAME = GitHub;
 				TargetAttributes = {
 					57A4D1AF1BA13D7A00F7D4B1 = {
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0830;
 					};
 					7DFBED021CDB8C9500EE435B = {
 						CreatedOnToolsVersion = 7.3.1;
@@ -615,11 +631,11 @@
 					};
 					A9B315531B3940610001CB9C = {
 						CreatedOnToolsVersion = 7.0;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0830;
 					};
 					D04725E919E49ED7006002AA = {
 						CreatedOnToolsVersion = 6.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0830;
 					};
 					D04725F419E49ED7006002AA = {
 						CreatedOnToolsVersion = 6.1;
@@ -627,7 +643,7 @@
 					};
 					D047260B19E49F82006002AA = {
 						CreatedOnToolsVersion = 6.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0830;
 					};
 					D047261519E49F82006002AA = {
 						CreatedOnToolsVersion = 6.1;
@@ -716,6 +732,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				57A4D1B71BA13D7A00F7D4B1 /* ObjectiveCBridging.swift in Sources */,
+				9AB5CD6C1EDAC351004ECB57 /* RACScheduler+SwiftSupport.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -733,6 +750,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A9B315BF1B3940810001CB9C /* ObjectiveCBridging.swift in Sources */,
+				9AB5CD6B1EDAC351004ECB57 /* RACScheduler+SwiftSupport.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -741,6 +759,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D0C312DF19EF2A5800984962 /* ObjectiveCBridging.swift in Sources */,
+				9AB5CD691EDAC351004ECB57 /* RACScheduler+SwiftSupport.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -758,6 +777,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D0C312E019EF2A5800984962 /* ObjectiveCBridging.swift in Sources */,
+				9AB5CD6A1EDAC351004ECB57 /* RACScheduler+SwiftSupport.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -807,6 +827,7 @@
 					"DTRACE_PROBES_DISABLED=1",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridge/Info.plist;
+				MODULEMAP_FILE = "$(SRCROOT)/ReactiveObjCBridge/module.modulemap";
 			};
 			name = Debug;
 		};
@@ -826,6 +847,7 @@
 					"DTRACE_PROBES_DISABLED=1",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridge/Info.plist;
+				MODULEMAP_FILE = "$(SRCROOT)/ReactiveObjCBridge/module.modulemap";
 			};
 			name = Test;
 		};
@@ -845,6 +867,7 @@
 					"DTRACE_PROBES_DISABLED=1",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridge/Info.plist;
+				MODULEMAP_FILE = "$(SRCROOT)/ReactiveObjCBridge/module.modulemap";
 			};
 			name = Release;
 		};
@@ -864,6 +887,7 @@
 					"DTRACE_PROBES_DISABLED=1",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridge/Info.plist;
+				MODULEMAP_FILE = "$(SRCROOT)/ReactiveObjCBridge/module.modulemap";
 			};
 			name = Profile;
 		};
@@ -878,7 +902,6 @@
 					"$(PROJECT_DIR)/build/Debug-appletvos",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridgeTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};
 			name = Debug;
@@ -894,7 +917,6 @@
 					"$(PROJECT_DIR)/build/Debug-appletvos",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridgeTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};
 			name = Test;
@@ -910,7 +932,6 @@
 					"$(PROJECT_DIR)/build/Debug-appletvos",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridgeTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};
 			name = Release;
@@ -926,7 +947,6 @@
 					"$(PROJECT_DIR)/build/Debug-appletvos",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridgeTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};
 			name = Profile;
@@ -947,6 +967,7 @@
 					"DTRACE_PROBES_DISABLED=1",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridge/Info.plist;
+				MODULEMAP_FILE = "$(SRCROOT)/ReactiveObjCBridge/module.modulemap";
 			};
 			name = Debug;
 		};
@@ -966,6 +987,7 @@
 					"DTRACE_PROBES_DISABLED=1",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridge/Info.plist;
+				MODULEMAP_FILE = "$(SRCROOT)/ReactiveObjCBridge/module.modulemap";
 			};
 			name = Test;
 		};
@@ -985,6 +1007,7 @@
 					"DTRACE_PROBES_DISABLED=1",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridge/Info.plist;
+				MODULEMAP_FILE = "$(SRCROOT)/ReactiveObjCBridge/module.modulemap";
 			};
 			name = Release;
 		};
@@ -1004,6 +1027,7 @@
 					"DTRACE_PROBES_DISABLED=1",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridge/Info.plist;
+				MODULEMAP_FILE = "$(SRCROOT)/ReactiveObjCBridge/module.modulemap";
 			};
 			name = Profile;
 		};
@@ -1059,7 +1083,7 @@
 				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = ReactiveObjCBridge/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "$(SRCROOT)/ReactiveObjCBridge/module.modulemap";
 			};
 			name = Debug;
 		};
@@ -1075,7 +1099,7 @@
 				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = ReactiveObjCBridge/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "$(SRCROOT)/ReactiveObjCBridge/module.modulemap";
 			};
 			name = Release;
 		};
@@ -1089,7 +1113,6 @@
 					"$(PROJECT_DIR)/build/Debug",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridgeTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};
 			name = Debug;
@@ -1104,7 +1127,6 @@
 					"$(PROJECT_DIR)/build/Debug",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridgeTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};
 			name = Release;
@@ -1121,7 +1143,7 @@
 					"$(PROJECT_DIR)/build/Debug-iphoneos",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridge/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "$(SRCROOT)/ReactiveObjCBridge/module.modulemap";
 			};
 			name = Debug;
 		};
@@ -1137,7 +1159,7 @@
 					"$(PROJECT_DIR)/build/Debug-iphoneos",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridge/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "$(SRCROOT)/ReactiveObjCBridge/module.modulemap";
 			};
 			name = Release;
 		};
@@ -1151,7 +1173,6 @@
 					"$(PROJECT_DIR)/build/Debug-iphoneos",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridgeTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};
 			name = Debug;
@@ -1166,7 +1187,6 @@
 					"$(PROJECT_DIR)/build/Debug-iphoneos",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridgeTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};
 			name = Release;
@@ -1202,7 +1222,7 @@
 				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = ReactiveObjCBridge/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "$(SRCROOT)/ReactiveObjCBridge/module.modulemap";
 			};
 			name = Profile;
 		};
@@ -1216,7 +1236,6 @@
 					"$(PROJECT_DIR)/build/Debug",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridgeTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};
 			name = Profile;
@@ -1233,7 +1252,7 @@
 					"$(PROJECT_DIR)/build/Debug-iphoneos",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridge/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "$(SRCROOT)/ReactiveObjCBridge/module.modulemap";
 			};
 			name = Profile;
 		};
@@ -1247,7 +1266,6 @@
 					"$(PROJECT_DIR)/build/Debug-iphoneos",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridgeTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};
 			name = Profile;
@@ -1283,7 +1301,7 @@
 				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = ReactiveObjCBridge/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "$(SRCROOT)/ReactiveObjCBridge/module.modulemap";
 			};
 			name = Test;
 		};
@@ -1297,7 +1315,6 @@
 					"$(PROJECT_DIR)/build/Debug",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridgeTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};
 			name = Test;
@@ -1314,7 +1331,7 @@
 					"$(PROJECT_DIR)/build/Debug-iphoneos",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridge/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "$(SRCROOT)/ReactiveObjCBridge/module.modulemap";
 			};
 			name = Test;
 		};
@@ -1328,7 +1345,6 @@
 					"$(PROJECT_DIR)/build/Debug-iphoneos",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridgeTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};
 			name = Test;

--- a/ReactiveObjCBridge/ObjectiveCBridging.swift
+++ b/ReactiveObjCBridge/ObjectiveCBridging.swift
@@ -25,7 +25,16 @@ extension SignalProducerProtocol {
 	}
 }
 
-extension RACDisposable: Disposable {}
+extension RACDisposable: Disposable {
+	public convenience init(_ disposable: Disposable?) {
+		if let disposable = disposable {
+			self.init(block: disposable.dispose)
+		} else {
+			self.init()
+		}
+	}
+}
+
 extension RACScheduler: DateScheduler {
 	/// The current date, as determined by this scheduler.
 	public var currentDate: Date {
@@ -82,6 +91,7 @@ extension ImmediateScheduler {
 	/// Create `RACScheduler` that performs actions instantly.
 	///
 	/// - returns: `RACScheduler` that instantly performs actions.
+	@available(*, deprecated, message:"Use `RACScheduler.immediate` directly, or `RACScheduler.init` in a generic context.")
 	public func toRACScheduler() -> RACScheduler {
 		return RACScheduler.immediate()
 	}
@@ -91,8 +101,9 @@ extension UIScheduler {
 	/// Create `RACScheduler` for `UIScheduler`
 	///
 	/// - returns: `RACScheduler` instance that queues events on main thread.
+	@available(*, deprecated, message:"Use `RACScheduler.init` to wrap an `UIScheduler` instead.")
 	public func toRACScheduler() -> RACScheduler {
-		return RACScheduler.mainThread()
+		return RACScheduler(self)
 	}
 }
 
@@ -101,119 +112,191 @@ extension QueueScheduler {
 	///
 	/// - returns: Instance `RACScheduler` that queues events on
 	///            `QueueScheduler`'s queue.
+	@available(*, deprecated, message:"Use `RACScheduler.init` to wrap a `QueueScheduler` instead.")
 	public func toRACScheduler() -> RACScheduler {
-		return RACTargetQueueScheduler(name: "org.reactivecocoa.ReactiveObjCBridge.QueueScheduler.toRACScheduler()", targetQueue: queue)
+		return RACScheduler(self)
 	}
+}
+
+extension RACScheduler {
+	/// Create a `RACScheduler` that wraps the given scheduler.
+	///
+	/// - parameters:
+	///   - scheduler: The `Scheduler` to wrap.
+	///
+	/// - returns: A `RACScheduler` that schedules blocks to `scheduler`.
+	public convenience init(_ scheduler: Scheduler) {
+		self.init(racSwiftScheduler: RACSwiftScheduler(wrapping: scheduler))
+	}
+
+	/// Create a `RACScheduler` that wraps the given scheduler.
+	///
+	/// - parameters:
+	///   - scheduler: The `DateScheduler` to wrap.
+	///
+	/// - returns: A `RACScheduler` that schedules blocks to `scheduler`.
+	public convenience init(_ scheduler: DateScheduler) {
+		self.init(racSwiftScheduler: RACSwiftScheduler(wrapping: scheduler))
+	}
+}
+
+private final class RACSwiftScheduler: RACScheduler {
+	enum Backing {
+		case scheduler(Scheduler)
+		case dateScheduler(DateScheduler)
+	}
+
+	private let base: Backing
+
+	init(wrapping base: Scheduler) {
+		self.base = .scheduler(base)
+	}
+
+	init(wrapping base: DateScheduler) {
+		self.base = .dateScheduler(base)
+	}
+
+	private func wrap(_ block: @escaping () -> Void) -> () -> Void {
+		return {
+			Thread.current.threadDictionary["RACSchedulerCurrentSchedulerKey"] = self
+			block()
+			Thread.current.threadDictionary["RACSchedulerCurrentSchedulerKey"] = nil
+		}
+	}
+
+	open override func schedule(_ block: @escaping () -> Void) -> RACDisposable? {
+		switch base {
+		case let .scheduler(scheduler):
+			return scheduler.schedule(wrap(block)).map(RACDisposable.init)
+
+		case let .dateScheduler(scheduler):
+			return scheduler.schedule(wrap(block)).map(RACDisposable.init)
+		}
+	}
+
+	open override func after(_ date: Date, schedule block: @escaping () -> Swift.Void) -> RACDisposable? {
+		switch base {
+		case let .scheduler(scheduler):
+			Thread.sleep(until: date)
+			return scheduler.schedule(wrap(block)).map(RACDisposable.init)
+
+		case let .dateScheduler(scheduler):
+			return scheduler.schedule(after: date,
+			                          action: wrap(block)).map(RACDisposable.init)
+		}
+	}
+
+	open override func after(_ date: Date, repeatingEvery interval: TimeInterval, withLeeway leeway: TimeInterval, schedule block: @escaping () -> Void) -> RACDisposable? {
+		switch base {
+		case let .scheduler(scheduler):
+			assertionFailure("Undefined behavior.")
+			return scheduler.schedule(wrap(block)).map(RACDisposable.init)
+
+		case let .dateScheduler(scheduler):
+			return scheduler.schedule(after: date,
+			                          interval: .milliseconds(Int(interval * 1000)),
+			                          leeway: .milliseconds(Int(leeway * 1000)),
+			                          action: wrap(block))
+				.map(RACDisposable.init)
+		}
+	}
+}
+
+private func defaultNSError(_ message: String) -> NSError {
+	return Result<(), NSError>.error(message)
 }
 
 private func defaultNSError(_ message: String, file: String, line: Int) -> NSError {
 	return Result<(), NSError>.error(message, file: file, line: line)
 }
 
-/// Create a `SignalProducer` which will subscribe to the provided signal once
-/// for each invocation of `start()`.
-///
-/// - parameters:
-///   - signal: The signal to bridge to a signal producer.
-///   - file: Current file name.
-///   - line: Current line in file.
-///
-/// - returns: Signal producer created from the provided signal.
-public func bridgedSignalProducer<Value>(from signal: RACSignal<Value>, file: String = #file, line: Int = #line) -> SignalProducer<Value?, AnyError> {
-	return _bridgedSignalProducer(from: signal, file: file, line: line)
+@available(*, unavailable, renamed:"SignalProducer(_:)")
+public func bridgedSignalProducer<Value>(from signal: RACSignal<Value>) -> SignalProducer<Value?, AnyError> {
+	fatalError()
 }
 
-private func _bridgedSignalProducer<Value>(from signal: RACSignal<Value>, file: String = #file, line: Int = #line) -> SignalProducer<Value?, AnyError> {
-	return SignalProducer<Value?, AnyError> { observer, disposable in
-		let next: (_ value: Value?) -> Void = { obj in
-			observer.send(value: obj)
-		}
+// These overloads are deliberately placed in the protocol, so that the overload resolver
+// of Swift does not breakdown.
+extension SignalProducerProtocol where Error == AnyError {
+	/// Create a `SignalProducer` which will subscribe to the provided signal once
+	/// for each invocation of `start()`.
+	///
+	/// - parameters:
+	///   - signal: The signal to bridge to a signal producer.
+	public init<SignalValue>(_ signal: RACSignal<SignalValue>) where Value == SignalValue? {
+		self.init(bridging: signal)
+	}
 
-		let failed: (_ error: Swift.Error?) -> () = { error in
-			observer.send(error: AnyError(error ?? defaultNSError("Nil RACSignal error", file: file, line: line)))
-		}
+	fileprivate init<SignalValue>(bridging signal: RACSignal<SignalValue>) where Value == SignalValue? {
+		self.init { observer, disposable in
+			let failed: (_ error: Swift.Error?) -> () = { error in
+				observer.send(error: AnyError(error ?? defaultNSError("Nil RACSignal error")))
+			}
 
-		let completed = {
-			observer.sendCompleted()
+			disposable += signal.subscribeNext(observer.send(value:),
+			                                   error: failed,
+			                                   completed: observer.sendCompleted)
 		}
-
-		disposable += signal.subscribeNext(next, error: failed, completed: completed)
 	}
 }
 
-/// Create a `SignalProducer` of 1-tuples which will subscribe to the provided
-/// signal once for each invocation of `start()`.
-///
-/// - parameters:
-///   - signal: The signal of `RACOneTuple` objects to bridge to a signal producer of 1-tuples.
-///   - file: Current file name.
-///   - line: Current line in file.
-///
-/// - returns: Signal producer created from the provided signal.
-public func bridgedSignalProducer<First>(from signal: RACSignal<RACOneTuple<First>>, file: String = #file, line: Int = #line) -> SignalProducer<(First?)?, AnyError> {
-	return _bridgedSignalProducer(from: signal, file: file, line: line).map { $0.map(bridgedTuple) }
-}
+extension SignalProducer where Error == AnyError {
+	/// Create a `SignalProducer` of 1-tuples which will subscribe to the provided
+	/// signal once for each invocation of `start()`.
+	///
+	/// - parameters:
+	///   - signal: The signal of `RACOneTuple` objects to bridge to a signal producer of 1-tuples.
+	public init<First>(_ signal: RACSignal<RACOneTuple<First>>) where Value == (First?)? {
+		self = SignalProducer<RACOneTuple<First>?, AnyError>(bridging: signal)
+			.map { $0.map(repackTuple(from:)) }
+	}
 
-/// Create a `SignalProducer` of 2-tuples which will subscribe to the provided
-/// signal once for each invocation of `start()`.
-///
-/// - parameters:
-///   - signal: The signal of `RACTwoTuple` objects to bridge to a signal producer of 2-tuples.
-///   - file: Current file name.
-///   - line: Current line in file.
-///
-/// - returns: Signal producer created from the provided signal.
-public func bridgedSignalProducer<First, Second>(from signal: RACSignal<RACTwoTuple<First, Second>>, file: String = #file, line: Int = #line) -> SignalProducer<(First?, Second?)?, AnyError> {
-	return _bridgedSignalProducer(from: signal, file: file, line: line).map { $0.map(bridgedTuple) }
-}
+	/// Create a `SignalProducer` of 2-tuples which will subscribe to the provided
+	/// signal once for each invocation of `start()`.
+	///
+	/// - parameters:
+	///   - signal: The signal of `RACTwoTuple` objects to bridge to a signal producer of 2-tuples.
+	public init<First, Second>(_ signal: RACSignal<RACTwoTuple<First, Second>>) where Value == (First?, Second?)? {
+		self = SignalProducer<RACTwoTuple<First, Second>?, AnyError>(bridging: signal)
+			.map { $0.map(repackTuple) }
+	}
 
-/// Create a `SignalProducer` of 3-tuples which will subscribe to the provided
-/// signal once for each invocation of `start()`.
-///
-/// - parameters:
-///   - signal: The signal of `RACThreeTuple` objects to bridge to a signal producer of 3-tuples.
-///   - file: Current file name.
-///   - line: Current line in file.
-///
-/// - returns: Signal producer created from the provided signal.
-public func bridgedSignalProducer<First, Second, Third>(from signal: RACSignal<RACThreeTuple<First, Second, Third>>, file: String = #file, line: Int = #line) -> SignalProducer<(First?, Second?, Third?)?, AnyError> {
-	return _bridgedSignalProducer(from: signal, file: file, line: line).map { $0.map(bridgedTuple) }
-}
+	/// Create a `SignalProducer` of 3-tuples which will subscribe to the provided
+	/// signal once for each invocation of `start()`.
+	///
+	/// - parameters:
+	///   - signal: The signal of `RACThreeTuple` objects to bridge to a signal producer of 3-tuples.
+	public init<First, Second, Third>(_ signal: RACSignal<RACThreeTuple<First, Second, Third>>) where Value == (First?, Second?, Third?)? {
+		self = SignalProducer<RACThreeTuple<First, Second, Third>?, AnyError>(bridging: signal)
+			.map { $0.map(repackTuple) }
+	}
 
-/// Create a `SignalProducer` of 4-tuples which will subscribe to the provided
-/// signal once for each invocation of `start()`.
-///
-/// - parameters:
-///   - signal: The signal of `RACFourTuple` objects to bridge to a signal producer of 4-tuples.
-///   - file: Current file name.
-///   - line: Current line in file.
-///
-/// - returns: Signal producer created from the provided signal.
-public func bridgedSignalProducer<First, Second, Third, Fourth>(from signal: RACSignal<RACFourTuple<First, Second, Third, Fourth>>, file: String = #file, line: Int = #line) -> SignalProducer<(First?, Second?, Third?, Fourth?)?, AnyError> {
-	return _bridgedSignalProducer(from: signal, file: file, line: line).map { $0.map(bridgedTuple) }
-}
+	/// Create a `SignalProducer` of 4-tuples which will subscribe to the provided
+	/// signal once for each invocation of `start()`.
+	///
+	/// - parameters:
+	///   - signal: The signal of `RACFourTuple` objects to bridge to a signal producer of 4-tuples.
+	public init<First, Second, Third, Fourth>(_ signal: RACSignal<RACFourTuple<First, Second, Third, Fourth>>) where Value == (First?, Second?, Third?, Fourth?)? {
+		self = SignalProducer<RACFourTuple<First, Second, Third, Fourth>?, AnyError>(bridging: signal)
+			.map { $0.map(repackTuple) }
+	}
 
-/// Create a `SignalProducer` of 5-tuples which will subscribe to the provided
-/// signal once for each invocation of `start()`.
-///
-/// - parameters:
-///   - signal: The signal of `RACFiveTuple` objects to bridge to a signal producer of 5-tuples.
-///   - file: Current file name.
-///   - line: Current line in file.
-///
-/// - returns: Signal producer created from the provided signal.
-public func bridgedSignalProducer<First, Second, Third, Fourth, Fifth>(from signal: RACSignal<RACFiveTuple<First, Second, Third, Fourth, Fifth>>, file: String = #file, line: Int = #line) -> SignalProducer<(First?, Second?, Third?, Fourth?, Fifth?)?, AnyError> {
-	return _bridgedSignalProducer(from: signal, file: file, line: line).map { $0.map(bridgedTuple) }
+	/// Create a `SignalProducer` of 5-tuples which will subscribe to the provided
+	/// signal once for each invocation of `start()`.
+	///
+	/// - parameters:
+	///   - signal: The signal of `RACFiveTuple` objects to bridge to a signal producer of 5-tuples.
+	public init<First, Second, Third, Fourth, Fifth>(_ signal: RACSignal<RACFiveTuple<First, Second, Third, Fourth, Fifth>>) where Value == (First?, Second?, Third?, Fourth?, Fifth?)? {
+		self = SignalProducer<RACFiveTuple<First, Second, Third, Fourth, Fifth>?, AnyError>(bridging: signal)
+			.map { $0.map(repackTuple) }
+	}
 }
 
 extension SignalProducerProtocol where Value: AnyObject {
-	/// Create a `RACSignal` that will `start()` the producer once for each
-	/// subscription.
+	/// A bridged `RACSignal` that will `start()` the producer once for each subscription.
 	///
 	/// - note: Any `interrupted` events will be silently discarded.
-	///
-	/// - returns: `RACSignal` instantiated from `self`.
-	public func toRACSignal() -> RACSignal<Value> {
+	public var bridged: RACSignal<Value> {
 		return RACSignal<Value>.createSignal { subscriber in
 			let selfDisposable = self.start { event in
 				switch event {
@@ -228,24 +311,23 @@ extension SignalProducerProtocol where Value: AnyObject {
 				}
 			}
 
-			return RACDisposable {
-				selfDisposable.dispose()
-			}
+			return RACDisposable(selfDisposable)
 		}
 	}
+
+	@available(*, deprecated, message:"Use the `bridged` property instead.")
+	public func toRACSignal() -> RACSignal<Value> { return bridged }
 }
 
 extension SignalProducerProtocol where Value: OptionalProtocol, Value.Wrapped: AnyObject {
-	/// Create a `RACSignal` that will `start()` the producer once for each
-	/// subscription.
+	/// A bridged `RACSignal` that will `start()` the producer once for each subscription.
 	///
 	/// - note: Any `interrupted` events will be silently discarded.
+	///
 	/// - note: This overload is necessary to prevent `Optional.none` from
 	///         being bridged to `NSNull` (instead of `nil`).
 	///         See ReactiveObjCBridge#5 for more details.
-	///
-	/// - returns: `RACSignal` instantiated from `self`.
-	public func toRACSignal() -> RACSignal<Value.Wrapped> {
+	public var bridged: RACSignal<Value.Wrapped> {
 		return RACSignal<Value.Wrapped>.createSignal { subscriber in
 			let selfDisposable = self.start { event in
 				switch event {
@@ -260,20 +342,19 @@ extension SignalProducerProtocol where Value: OptionalProtocol, Value.Wrapped: A
 				}
 			}
 			
-			return RACDisposable {
-				selfDisposable.dispose()
-			}
+			return RACDisposable(selfDisposable)
 		}
 	}
+
+	@available(*, deprecated, message:"Use the `bridged` property instead.")
+	public func toRACSignal() -> RACSignal<Value.Wrapped> { return bridged }
 }
 
 extension SignalProtocol where Value: AnyObject {
-	/// Create a `RACSignal` that will observe the given signal.
+	/// A bridged `RACSignal` that will observe the given signal.
 	///
 	/// - note: Any `interrupted` events will be silently discarded.
-	///
-	/// - returns: `RACSignal` instantiated from `self`.
-	public func toRACSignal() -> RACSignal<Value> {
+	public var bridged: RACSignal<Value> {
 		return RACSignal<Value>.createSignal { subscriber in
 			let selfDisposable = self.observe { event in
 				switch event {
@@ -288,23 +369,23 @@ extension SignalProtocol where Value: AnyObject {
 				}
 			}
 
-			return RACDisposable {
-				selfDisposable?.dispose()
-			}
+			return RACDisposable(selfDisposable)
 		}
 	}
+
+	@available(*, deprecated, message:"Use the `bridged` property instead.")
+	public func toRACSignal() -> RACSignal<Value> { return bridged }
 }
 
 extension SignalProtocol where Value: OptionalProtocol, Value.Wrapped: AnyObject {
-	/// Create a `RACSignal` that will observe the given signal.
+	/// A bridged `RACSignal` that will observe the given signal.
 	///
 	/// - note: Any `interrupted` events will be silently discarded.
+	///
 	/// - note: This overload is necessary to prevent `Optional.none` from 
 	///         being bridged to `NSNull` (instead of `nil`).
 	///         See ReactiveObjCBridge#5 for more details.
-	///
-	/// - returns: `RACSignal` instantiated from `self`.
-	public func toRACSignal() -> RACSignal<Value.Wrapped> {
+	public var bridged: RACSignal<Value.Wrapped> {
 		return RACSignal<Value.Wrapped>.createSignal { subscriber in
 			let selfDisposable = self.observe { event in
 				switch event {
@@ -319,118 +400,117 @@ extension SignalProtocol where Value: OptionalProtocol, Value.Wrapped: AnyObject
 				}
 			}
 			
-			return RACDisposable {
-				selfDisposable?.dispose()
-			}
+			return RACDisposable(selfDisposable)
 		}
 	}
+
+	@available(*, deprecated, message:"Use the `bridged` property instead.")
+	public func toRACSignal() -> RACSignal<Value.Wrapped> { return bridged }
 }
 
-// MARK: -
-
-extension ActionProtocol {
+extension Action {
 	fileprivate var isCommandEnabled: RACSignal<NSNumber> {
-		return self.isEnabled.producer
-			.map { $0 as NSNumber }
-			.toRACSignal()
+		return self.isEnabled.producer.map { $0 as NSNumber }.bridged
 	}
 }
 
-/// Creates an Action that will execute the receiver.
-///
-/// - note: The returned Action will not necessarily be marked as executing
-///         when the command is. However, the reverse is always true: the
-///         RACCommand will always be marked as executing when the action
-///         is.
-///
-/// - parameters:
-///   - command: The command to bridge to an action.
-///   - file: Current file name.
-///   - line: Current line in file.
-///
-/// - returns: Action created from `self`.
-public func bridgedAction<Input, Output>(from command: RACCommand<Input, Output>, file: String = #file, line: Int = #line) -> Action<Input?, Output?, AnyError> {
-	let enabledProperty = MutableProperty(true)
+@available(*, unavailable, renamed:"Action(_:)")
+public func bridgedAction<Input, Output>(from command: RACCommand<Input, Output>) -> Action<Input?, Output?, AnyError> {
+	fatalError()
+}
 
-	enabledProperty <~ bridgedSignalProducer(from: command.enabled)
-		.map { $0 as! Bool }
-		.flatMapError { _ in SignalProducer<Bool, NoError>(value: false) }
+extension Action where Error == AnyError {
+	/// Create an Action that wraps the given command.
+	///
+	/// - note: The created `Action` will not necessarily be marked as executing
+	///         when the command is. However, the reverse is always true: the
+	///         `RACCommand` will always be marked as executing when the action
+	///         is.
+	///
+	/// - parameters:
+	///   - command: The command to wrap.
+	public convenience init<CommandInput, CommandOutput>(
+		_ command: RACCommand<CommandInput, CommandOutput>
+	) where Input == CommandInput?, Output == CommandOutput? {
+		let enabledProperty = MutableProperty(true)
 
-	return Action<Input?, Output?, AnyError>(enabledIf: enabledProperty) { input -> SignalProducer<Output?, AnyError> in
-		let signal: RACSignal<Output> = command.execute(input)
+		enabledProperty <~ SignalProducer(command.enabled)
+			.map { $0 as! Bool }
+			.flatMapError { _ in SignalProducer<Bool, NoError>(value: false) }
 
-		return bridgedSignalProducer(from: signal)
+		self.init(enabledIf: enabledProperty) { input -> SignalProducer<Output, AnyError> in
+			let signal: RACSignal<CommandOutput> = command.execute(input)
+
+			return SignalProducer(signal)
+		}
 	}
 }
 
-extension ActionProtocol where Input: AnyObject, Output: AnyObject {
-	/// Creates a RACCommand that will execute the action.
+extension Action where Input: AnyObject, Output: AnyObject {
+	/// A bridged `RACCommand` that will execute the action.
 	///
 	/// - note: The returned command will not necessarily be marked as executing
 	///         when the action is. However, the reverse is always true: the Action
-	///         will always be marked as executing when the RACCommand is.
-	///
-	/// - returns: `RACCommand` with bound action.
-	public func toRACCommand() -> RACCommand<Input, Output> {
+	///         will always be marked as executing when the `RACCommand` is.
+	public var bridged: RACCommand<Input, Output> {
 		return RACCommand<Input, Output>(enabled: action.isCommandEnabled) { input -> RACSignal<Output> in
-			return self.apply(input!)
-				.toRACSignal()
+			return self.apply(input!).bridged
 		}
 	}
+
+	@available(*, deprecated, message:"Use the `bridged` property instead.")
+	public func toRACCommand() -> RACCommand<Input, Output> { return bridged }
 }
 
-extension ActionProtocol where Input: OptionalProtocol, Input.Wrapped: AnyObject, Output: AnyObject {
-	/// Creates a RACCommand that will execute the action.
+extension Action where Input: OptionalProtocol, Input.Wrapped: AnyObject, Output: AnyObject {
+	/// A bridged `RACCommand` that will execute the action.
 	///
 	/// - note: The returned command will not necessarily be marked as executing
 	///         when the action is. However, the reverse is always true: the Action
-	///         will always be marked as executing when the RACCommand is.
-	///
-	/// - returns: `RACCommand` with bound action.
-	public func toRACCommand() -> RACCommand<Input.Wrapped, Output> {
+	///         will always be marked as executing when the `RACCommand` is.
+	public var bridged: RACCommand<Input.Wrapped, Output> {
 		return RACCommand<Input.Wrapped, Output>(enabled: action.isCommandEnabled) { input -> RACSignal<Output> in
-			return self
-				.apply(Input(reconstructing: input))
-				.toRACSignal()
+			return self.apply(Input(reconstructing: input)).bridged
 		}
 	}
+
+	@available(*, deprecated, message:"Use the `bridged` property instead.")
+	public func toRACCommand() -> RACCommand<Input.Wrapped, Output> { return bridged }
 }
 
-extension ActionProtocol where Input: AnyObject, Output: OptionalProtocol, Output.Wrapped: AnyObject {
-	/// Creates a RACCommand that will execute the action.
+extension Action where Input: AnyObject, Output: OptionalProtocol, Output.Wrapped: AnyObject {
+	/// A bridged `RACCommand` that will execute the action.
 	///
 	/// - note: The returned command will not necessarily be marked as executing
 	///         when the action is. However, the reverse is always true: the Action
-	///         will always be marked as executing when the RACCommand is.
-	///
-	/// - returns: `RACCommand` with bound action.
-	public func toRACCommand() -> RACCommand<Input, Output.Wrapped> {
+	///         will always be marked as executing when the `RACCommand` is.
+	public var bridged: RACCommand<Input, Output.Wrapped> {
 		return RACCommand<Input, Output.Wrapped>(enabled: action.isCommandEnabled) { input -> RACSignal<Output.Wrapped> in
-			return self
-				.apply(input!)
-				.toRACSignal()
+			return self.apply(input!).bridged
 		}
 	}
+
+	@available(*, deprecated, message:"Use the `bridged` property instead.")
+	public func toRACCommand() -> RACCommand<Input, Output.Wrapped> { return bridged }
 }
 
-extension ActionProtocol where Input: OptionalProtocol, Input.Wrapped: AnyObject, Output: OptionalProtocol, Output.Wrapped: AnyObject {
-	/// Creates a RACCommand that will execute the action.
+extension Action where Input: OptionalProtocol, Input.Wrapped: AnyObject, Output: OptionalProtocol, Output.Wrapped: AnyObject {
+	/// A bridged `RACCommand` that will execute the action.
 	///
 	/// - note: The returned command will not necessarily be marked as executing
 	///         when the action is. However, the reverse is always true: the Action
 	///         will always be marked as executing when the RACCommand is.
-	///
-	/// - returns: `RACCommand` with bound action.
-	public func toRACCommand() -> RACCommand<Input.Wrapped, Output.Wrapped> {
+	public var bridged: RACCommand<Input.Wrapped, Output.Wrapped> {
 		return RACCommand<Input.Wrapped, Output.Wrapped>(enabled: action.isCommandEnabled) { input -> RACSignal<Output.Wrapped> in
-			return self
-				.apply(Input(reconstructing: input))
-				.toRACSignal()
+			return self.apply(Input(reconstructing: input)).bridged
 		}
 	}
+
+	@available(*, deprecated, message:"Use the `bridged` property instead.")
+	public func toRACCommand() -> RACCommand<Input.Wrapped, Output.Wrapped> { return bridged }
 }
 
-// MARK: Tuples
+// MARK: - Tuple Mapper
 
 /// Creates a Swift tuple with one element.
 ///
@@ -438,7 +518,7 @@ extension ActionProtocol where Input: OptionalProtocol, Input.Wrapped: AnyObject
 ///   - tuple: The `RACOneTuple` to bridge to a Swift tuple.
 ///
 /// - returns: Swift tuple created from the provided `RACOneTuple` object.
-public func bridgedTuple<First>(from tuple: RACOneTuple<First>) -> (First?) {
+public func repackTuple<First>(from tuple: RACOneTuple<First>) -> (First?) {
 	return (tuple.first)
 }
 
@@ -448,7 +528,7 @@ public func bridgedTuple<First>(from tuple: RACOneTuple<First>) -> (First?) {
 ///   - tuple: The `RACTwoTuple` to bridge to a Swift tuple.
 ///
 /// - returns: Swift tuple created from the provided `RACTwoTuple` object.
-public func bridgedTuple<First, Second>(from tuple: RACTwoTuple<First, Second>) -> (First?, Second?) {
+public func repackTuple<First, Second>(from tuple: RACTwoTuple<First, Second>) -> (First?, Second?) {
 	return (tuple.first, tuple.second)
 }
 
@@ -458,7 +538,7 @@ public func bridgedTuple<First, Second>(from tuple: RACTwoTuple<First, Second>) 
 ///   - tuple: The `RACThreeTuple` to bridge to a Swift tuple.
 ///
 /// - returns: Swift tuple created from the provided `RACThreeTuple` object.
-public func bridgedTuple<First, Second, Third>(from tuple: RACThreeTuple<First, Second, Third>) -> (First?, Second?, Third?) {
+public func repackTuple<First, Second, Third>(from tuple: RACThreeTuple<First, Second, Third>) -> (First?, Second?, Third?) {
 	return (tuple.first, tuple.second, tuple.third)
 }
 
@@ -468,7 +548,7 @@ public func bridgedTuple<First, Second, Third>(from tuple: RACThreeTuple<First, 
 ///   - tuple: The `RACFourTuple` to bridge to a Swift tuple.
 ///
 /// - returns: Swift tuple created from the provided `RACFourTuple` object.
-public func bridgedTuple<First, Second, Third, Fourth>(from tuple: RACFourTuple<First, Second, Third, Fourth>) -> (First?, Second?, Third?, Fourth?) {
+public func repackTuple<First, Second, Third, Fourth>(from tuple: RACFourTuple<First, Second, Third, Fourth>) -> (First?, Second?, Third?, Fourth?) {
 	return (tuple.first, tuple.second, tuple.third, tuple.fourth)
 }
 
@@ -478,7 +558,7 @@ public func bridgedTuple<First, Second, Third, Fourth>(from tuple: RACFourTuple<
 ///   - tuple: The `RACFiveTuple` to bridge to a Swift tuple.
 ///
 /// - returns: Swift tuple created from the provided `RACFiveTuple` object.
-public func bridgedTuple<First, Second, Third, Fourth, Fifth>(from tuple: RACFiveTuple<First, Second, Third, Fourth, Fifth>) -> (First?, Second?, Third?, Fourth?, Fifth?) {
+public func repackTuple<First, Second, Third, Fourth, Fifth>(from tuple: RACFiveTuple<First, Second, Third, Fourth, Fifth>) -> (First?, Second?, Third?, Fourth?, Fifth?) {
 	return (tuple.first, tuple.second, tuple.third, tuple.fourth, tuple.fifth)
 }
 

--- a/ReactiveObjCBridge/RACScheduler+SwiftSupport.h
+++ b/ReactiveObjCBridge/RACScheduler+SwiftSupport.h
@@ -1,0 +1,5 @@
+#import <ReactiveObjC/ReactiveObjC.h>
+
+@interface RACScheduler (SwiftSupport)
++ (RACScheduler *) schedulerWithRACSwiftScheduler:(RACScheduler*)scheduler;
+@end

--- a/ReactiveObjCBridge/RACScheduler+SwiftSupport.m
+++ b/ReactiveObjCBridge/RACScheduler+SwiftSupport.m
@@ -1,0 +1,8 @@
+#import <RACScheduler+SwiftSupport.h>
+#import <ReactiveObjC/ReactiveObjC.h>
+
+@implementation RACScheduler (SwiftSupport)
++ (RACScheduler *) schedulerWithRACSwiftScheduler:(RACScheduler*)scheduler {
+	return scheduler;
+}
+@end

--- a/ReactiveObjCBridge/module.modulemap
+++ b/ReactiveObjCBridge/module.modulemap
@@ -1,0 +1,6 @@
+framework module ReactiveObjCBridge {
+	umbrella header "ReactiveObjCBridge.h"
+	private header "RACScheduler+SwiftSupport.h"
+
+	export *
+}


### PR DESCRIPTION
Swift API Guidelines prefer initialisers whenever it is possible. So a bunch of stuff is now converted to be initialisers.

1. `bridgedSignalProducer` is renamed to `SignalProducer.init(_:)`.

1. `bridgedAction` is renamed to `Action.init(_:)`.

1. `Scheduler.toRACScheduler()` is deprecated in favour of the new `RACScheduler.init(_:)`, which wraps an instance of `Scheduler` or `DateScheduler`.

1. Introduce `RACDisposable.init(_:)` which wraps an instance of `Disposable`.

1. `toRACCommand()` and `toRACSignal()` are deprecated in favour of a `bridged` computed property. Ideally these should be `RACCommand.init(_:)` and `RACSignal.init(_:)`. However, even with Xcode 8.3 the compiler is still extremely conservative with Objective-C lightweight generics.