### PR TITLE
fix exhaustive switch error in Xcode 9

### DIFF
--- a/ReactiveObjCBridge/ObjectiveCBridging.swift
+++ b/ReactiveObjCBridge/ObjectiveCBridging.swift
@@ -486,15 +486,30 @@ public func bridgedTuple<First, Second, Third, Fourth, Fifth>(from tuple: RACFiv
 
 extension DispatchTimeInterval {
 	fileprivate var timeInterval: TimeInterval {
-		switch self {
-		case let .seconds(s):
-			return TimeInterval(s)
-		case let .milliseconds(ms):
-			return TimeInterval(TimeInterval(ms) / 1000.0)
-		case let .microseconds(us):
-			return TimeInterval(UInt64(us) * NSEC_PER_USEC) / TimeInterval(NSEC_PER_SEC)
-		case let .nanoseconds(ns):
-			return TimeInterval(ns) / TimeInterval(NSEC_PER_SEC)
-		}
+		#if swift(>=3.2)
+			switch self {
+			case let .seconds(s):
+				return TimeInterval(s)
+			case let .milliseconds(ms):
+				return TimeInterval(TimeInterval(ms) / 1000.0)
+			case let .microseconds(us):
+				return TimeInterval(Int64(us) * Int64(NSEC_PER_USEC)) / TimeInterval(NSEC_PER_SEC)
+			case let .nanoseconds(ns):
+				return TimeInterval(ns) / TimeInterval(NSEC_PER_SEC)
+			case .never:
+				return .infinity
+			}
+		#else
+			switch self {
+			case let .seconds(s):
+				return TimeInterval(s)
+			case let .milliseconds(ms):
+				return TimeInterval(TimeInterval(ms) / 1000.0)
+			case let .microseconds(us):
+				return TimeInterval(Int64(us) * Int64(NSEC_PER_USEC)) / TimeInterval(NSEC_PER_SEC)
+			case let .nanoseconds(ns):
+				return TimeInterval(ns) / TimeInterval(NSEC_PER_SEC)
+			}
+		#endif
 	}
 }


### PR DESCRIPTION
Accounting for the new case in `DispatchTimeInterval` has been done in other ReactiveCocoa projects, but not this one.