### PR TITLE
Resolve warning

### DIFF
--- a/ReactiveObjCBridgeTests/ObjectiveCBridgingSpec.swift
+++ b/ReactiveObjCBridgeTests/ObjectiveCBridgingSpec.swift
@@ -185,7 +185,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					let racSignal = producer.toRACSignal().materialize()
 
 					let event = racSignal.first()
-					expect(event?.error as? NSError) == TestError.error1 as NSError
+					expect(event?.error as NSError?) == TestError.error1 as NSError
 				}
 
 				it("should maintain userInfo on NSError") {


### PR DESCRIPTION
Resolve the waring: `Conditional downcast from 'Error?' to 'NSError' is a bridging conversion; did you mean to use 'as'?`