### PR TITLE
Property bridging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
       env:
         - JOB=CARTHAGE-watchOS
     - script:
-      - pod repo update --verbose
+      - pod repo update --silent
       - pod lib lint --allow-warnings
       env:
         - JOB=PODSPEC

--- a/ReactiveObjCBridge/ObjectiveCBridging.swift
+++ b/ReactiveObjCBridge/ObjectiveCBridging.swift
@@ -11,19 +11,7 @@ import ReactiveObjC
 import ReactiveSwift
 import Result
 
-extension SignalProtocol {
-	/// Turns each value into an Optional.
-	fileprivate func optionalize() -> Signal<Value?, Error> {
-		return signal.map(Optional.init)
-	}
-}
-
-extension SignalProducerProtocol {
-	/// Turns each value into an Optional.
-	fileprivate func optionalize() -> SignalProducer<Value?, Error> {
-		return producer.lift { $0.optionalize() }
-	}
-}
+// MARK: - Disposables
 
 extension RACDisposable: Disposable {
 	public convenience init(_ disposable: Disposable?) {
@@ -34,6 +22,8 @@ extension RACDisposable: Disposable {
 		}
 	}
 }
+
+// MARK: - Schedulers
 
 extension RACScheduler: DateScheduler {
 	/// The current date, as determined by this scheduler.
@@ -202,13 +192,7 @@ private final class RACSwiftScheduler: RACScheduler {
 	}
 }
 
-private func defaultNSError(_ message: String) -> NSError {
-	return Result<(), NSError>.error(message)
-}
-
-private func defaultNSError(_ message: String, file: String, line: Int) -> NSError {
-	return Result<(), NSError>.error(message, file: file, line: line)
-}
+// MARK: - Signals
 
 @available(*, unavailable, renamed:"SignalProducer(_:)")
 public func bridgedSignalProducer<Value>(from signal: RACSignal<Value>) -> SignalProducer<Value?, AnyError> {
@@ -299,6 +283,14 @@ extension SignalProducer where Error == AnyError {
 			                                   completed: observer.sendCompleted)
 		}
 	}
+}
+
+private func defaultNSError(_ message: String) -> NSError {
+	return Result<(), NSError>.error(message)
+}
+
+private func defaultNSError(_ message: String, file: String, line: Int) -> NSError {
+	return Result<(), NSError>.error(message, file: file, line: line)
 }
 
 extension SignalProducerProtocol where Value: AnyObject {
@@ -417,6 +409,22 @@ extension SignalProtocol where Value: OptionalProtocol, Value.Wrapped: AnyObject
 	public func toRACSignal() -> RACSignal<Value.Wrapped> { return bridged }
 }
 
+extension SignalProtocol {
+	/// Turns each value into an Optional.
+	fileprivate func optionalize() -> Signal<Value?, Error> {
+		return signal.map(Optional.init)
+	}
+}
+
+extension SignalProducerProtocol {
+	/// Turns each value into an Optional.
+	fileprivate func optionalize() -> SignalProducer<Value?, Error> {
+		return producer.lift { $0.optionalize() }
+	}
+}
+
+// MARK: - Actions
+
 extension Action {
 	fileprivate var isEnabled: RACSignal<NSNumber> {
 		return self.isEnabled.producer.map { $0 as NSNumber }.bridged
@@ -519,7 +527,7 @@ extension Action where Input: OptionalProtocol, Input.Wrapped: AnyObject, Output
 	public func toRACCommand() -> RACCommand<Input.Wrapped, Output.Wrapped> { return bridged }
 }
 
-// MARK: Tuples
+// MARK: - Tuples
 
 /// Creates a Swift tuple with one element.
 ///

--- a/ReactiveObjCBridge/ObjectiveCBridging.swift
+++ b/ReactiveObjCBridge/ObjectiveCBridging.swift
@@ -426,32 +426,32 @@ extension Property where Value: AnyObject {
 }
 
 extension Property where Value: AnyObject {
-	/// A bridged `RACSignal` that will `start()` with the property's current
-	/// value (followed by all changes over time) for each subscription.
+	/// A bridged `RACSignal` that will send the property's current value
+	/// (followed by all changes over time) for each subscription.
 	public var bridged: RACSignal<Value> {
 		return self.producer.bridged
 	}
 }
 
 extension Property where Value: OptionalProtocol, Value.Wrapped: AnyObject {
-	/// A bridged `RACSignal` that will `start()` with the property's current
-	/// value (followed by all changes over time) for each subscription.
+	/// A bridged `RACSignal` that will send the property's current value
+	/// (followed by all changes over time) for each subscription.
 	public var bridged: RACSignal<Value.Wrapped> {
 		return self.producer.map { $0.optional }.bridged
 	}
 }
 
 extension PropertyProtocol where Self.Value: AnyObject {
-	/// A bridged `RACSignal` that will `start()` with the property's current
-	/// value (followed by all changes over time) for each subscription.
+	/// A bridged `RACSignal` that will send the property's current value
+	/// (followed by all changes over time) for each subscription.
 	public var bridged: RACSignal<Value> {
 		return self.producer.bridged
 	}
 }
 
 extension PropertyProtocol where Self.Value: OptionalProtocol, Self.Value.Wrapped: AnyObject {
-	/// A bridged `RACSignal` that will `start()` with the property's current
-	/// value (followed by all changes over time) for each subscription.
+	/// A bridged `RACSignal` that will send the property's current value
+	/// (followed by all changes over time) for each subscription.
 	public var bridged: RACSignal<Value.Wrapped> {
 		return self.producer.map { $0.optional }.bridged
 	}

--- a/ReactiveObjCBridge/ObjectiveCBridging.swift
+++ b/ReactiveObjCBridge/ObjectiveCBridging.swift
@@ -423,6 +423,54 @@ extension SignalProducerProtocol {
 	}
 }
 
+// MARK: - Property
+
+extension Property where Value: AnyObject {
+	/// Initializes a composed property that first takes on `initial`, then each
+	/// value sent on the given `signal`.
+	///
+	/// - parameters:
+	///   - initial: Starting value for the property.
+	///   - values: The signal to bridge to a signal producer which will start
+	///             immediately and send values to the property.
+	public convenience init(initial value: Value, then signal: RACSignal<Value>) {
+		let producer = SignalProducer(signal).skipNil().flatMapError { _ in SignalProducer<Value, NoError>.empty }
+		self.init(initial: value, then: producer)
+	}
+}
+
+extension Property where Value: AnyObject {
+	/// A bridged `RACSignal` that will `start()` with the property's current
+	/// value (followed by all changes over time) for each subscription.
+	public var bridged: RACSignal<Value> {
+		return self.producer.bridged
+	}
+}
+
+extension Property where Value: OptionalProtocol, Value.Wrapped: AnyObject {
+	/// A bridged `RACSignal` that will `start()` with the property's current
+	/// value (followed by all changes over time) for each subscription.
+	public var bridged: RACSignal<Value.Wrapped> {
+		return self.producer.map { $0.optional }.bridged
+	}
+}
+
+extension PropertyProtocol where Self.Value: AnyObject {
+	/// A bridged `RACSignal` that will `start()` with the property's current
+	/// value (followed by all changes over time) for each subscription.
+	public var bridged: RACSignal<Value> {
+		return self.producer.bridged
+	}
+}
+
+extension PropertyProtocol where Self.Value: OptionalProtocol, Self.Value.Wrapped: AnyObject {
+	/// A bridged `RACSignal` that will `start()` with the property's current
+	/// value (followed by all changes over time) for each subscription.
+	public var bridged: RACSignal<Value.Wrapped> {
+		return self.producer.map { $0.optional }.bridged
+	}
+}
+
 // MARK: - Actions
 
 extension Action {

--- a/ReactiveObjCBridge/ObjectiveCBridging.swift
+++ b/ReactiveObjCBridge/ObjectiveCBridging.swift
@@ -409,20 +409,6 @@ extension SignalProtocol where Value: OptionalProtocol, Value.Wrapped: AnyObject
 	public func toRACSignal() -> RACSignal<Value.Wrapped> { return bridged }
 }
 
-extension SignalProtocol {
-	/// Turns each value into an Optional.
-	fileprivate func optionalize() -> Signal<Value?, Error> {
-		return signal.map(Optional.init)
-	}
-}
-
-extension SignalProducerProtocol {
-	/// Turns each value into an Optional.
-	fileprivate func optionalize() -> SignalProducer<Value?, Error> {
-		return producer.lift { $0.optionalize() }
-	}
-}
-
 // MARK: - Property
 
 extension Property where Value: AnyObject {


### PR DESCRIPTION
I found myself bridging between `RACSignal`s and `Property` values a lot, and thought this could be a generally useful (if small) feature.

Basically, this PR allows us to do:

```swift
// RACSignal -> Property
let racSignal = RACSignal<NSNumber>.return(NSNumber(value: 10))
let property = Property(initial: 0, then: racSignal) // Property<NSNumber> == 10


// Property -> RACSignal
let property = Property<Int>(initial: 0, then: SignalProducer(value: 10))
let racSignal = property.map(NSNumber.init(value:)).bridged // RACSignal<NSNumber>
```

I also deleted a couple of unused functions (I think they're not needed anymore) and rearranged things to be a bit more nicely grouped, with section headers etc.

Thoughts?