### PR TITLE
Update Podspec for ReactiveSwift 3.1.0 and ReactiveObjC 3.1.0

### DIFF
--- a/ReactiveObjCBridge.podspec
+++ b/ReactiveObjCBridge.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ReactiveObjCBridge"
-  s.version      = "3.0.0"
+  s.version      = "3.1.0"
   s.summary      = "Bridge between ReactiveObjC and ReactiveSwift"
   s.description  = <<-DESC
                    After the announcement of Swift, ReactiveCocoa was rewritten in Swift. This framework creates a bridge between those Swift and Objective-C APIs (now known as ReactiveSwift and ReactiveObjC respectively).
@@ -21,8 +21,8 @@ Pod::Spec.new do |s|
   s.private_header_files = 'ReactiveObjCBridge/RACScheduler+SwiftSupport.h'
   s.module_map = 'ReactiveObjCBridge/module.modulemap'
 
-  s.dependency 'ReactiveObjC', '~> 3.0.0'
-  s.dependency 'ReactiveSwift', '~> 3.0'
+  s.dependency 'ReactiveObjC', '~> 3.1'
+  s.dependency 'ReactiveSwift', '~> 3.1'
 
   s.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS[config=Release]" => "-suppress-warnings" }
 end


### PR DESCRIPTION
Carthage dependencies have been updated in #43 but the Podspec was not updated accordingly.