### PR TITLE
Avoid flag override when intergrated with CocoaPods.

### DIFF
--- a/ReactiveObjCBridge.podspec
+++ b/ReactiveObjCBridge.podspec
@@ -24,5 +24,5 @@ Pod::Spec.new do |s|
   s.dependency 'ReactiveObjC', '~> 3.1'
   s.dependency 'ReactiveSwift', '~> 3.1'
 
-  s.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS[config=Release]" => "-suppress-warnings" }
+  s.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS[config=Release]" => "$(inherited) -suppress-warnings" }
 end


### PR DESCRIPTION
By adding $(inherited) to OTHER_SWIFT_FLAGS[cnnfig=Release].

Fix issue mentioned in ReactiveCocoa/ReactiveSwift#628