### PR TITLE
Xcode 10 support

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Quick/Nimble" "v7.0.3"
+github "Quick/Nimble" "v7.1.2"
 github "Quick/Quick" "v1.2.0"
 github "ReactiveCocoa/ReactiveObjC" "3.1.0"
 github "ReactiveCocoa/ReactiveSwift" "3.1.0"

--- a/ReactiveObjCBridge.xcodeproj/project.pbxproj
+++ b/ReactiveObjCBridge.xcodeproj/project.pbxproj
@@ -1113,6 +1113,7 @@
 					"$(PROJECT_DIR)/build/Debug",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridgeTests/Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};
 			name = Debug;
@@ -1127,6 +1128,7 @@
 					"$(PROJECT_DIR)/build/Debug",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridgeTests/Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};
 			name = Release;
@@ -1236,6 +1238,7 @@
 					"$(PROJECT_DIR)/build/Debug",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridgeTests/Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};
 			name = Profile;
@@ -1315,6 +1318,7 @@
 					"$(PROJECT_DIR)/build/Debug",
 				);
 				INFOPLIST_FILE = ReactiveObjCBridgeTests/Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};
 			name = Test;

--- a/ReactiveObjCBridge/ObjectiveCBridging.swift
+++ b/ReactiveObjCBridge/ObjectiveCBridging.swift
@@ -164,7 +164,7 @@ private final class RACSwiftScheduler: RACScheduler {
 		}
 	}
 
-	open override func schedule(_ block: @escaping () -> Void) -> RACDisposable? {
+	override func schedule(_ block: @escaping () -> Void) -> RACDisposable? {
 		switch base {
 		case let .scheduler(scheduler):
 			return scheduler.schedule(wrap(block)).map(RACDisposable.init)
@@ -174,7 +174,7 @@ private final class RACSwiftScheduler: RACScheduler {
 		}
 	}
 
-	open override func after(_ date: Date, schedule block: @escaping () -> Swift.Void) -> RACDisposable? {
+	override func after(_ date: Date, schedule block: @escaping () -> Swift.Void) -> RACDisposable? {
 		switch base {
 		case let .scheduler(scheduler):
 			Thread.sleep(until: date)
@@ -186,7 +186,7 @@ private final class RACSwiftScheduler: RACScheduler {
 		}
 	}
 
-	open override func after(_ date: Date, repeatingEvery interval: TimeInterval, withLeeway leeway: TimeInterval, schedule block: @escaping () -> Void) -> RACDisposable? {
+	override func after(_ date: Date, repeatingEvery interval: TimeInterval, withLeeway leeway: TimeInterval, schedule block: @escaping () -> Void) -> RACDisposable? {
 		switch base {
 		case let .scheduler(scheduler):
 			assertionFailure("Undefined behavior.")

--- a/ReactiveObjCBridge/ObjectiveCBridging.swift
+++ b/ReactiveObjCBridge/ObjectiveCBridging.swift
@@ -418,7 +418,7 @@ extension SignalProtocol where Value: OptionalProtocol, Value.Wrapped: AnyObject
 }
 
 extension Action {
-	fileprivate var isEnabled: RACSignal<NSNumber> {
+	fileprivate var isEnabledSignal: RACSignal<NSNumber> {
 		return self.isEnabled.producer.map { $0 as NSNumber }.bridged
 	}
 }
@@ -462,7 +462,7 @@ extension Action where Input: AnyObject, Output: AnyObject {
 	///         when the action is. However, the reverse is always true: the Action
 	///         will always be marked as executing when the `RACCommand` is.
 	public var bridged: RACCommand<Input, Output> {
-		return RACCommand<Input, Output>(enabled: isEnabled) { input -> RACSignal<Output> in
+		return RACCommand<Input, Output>(enabled: isEnabledSignal) { input -> RACSignal<Output> in
 			return self.apply(input!).bridged
 		}
 	}
@@ -478,7 +478,7 @@ extension Action where Input: OptionalProtocol, Input.Wrapped: AnyObject, Output
 	///         when the action is. However, the reverse is always true: the Action
 	///         will always be marked as executing when the `RACCommand` is.
 	public var bridged: RACCommand<Input.Wrapped, Output> {
-		return RACCommand<Input.Wrapped, Output>(enabled: isEnabled) { input -> RACSignal<Output> in
+		return RACCommand<Input.Wrapped, Output>(enabled: isEnabledSignal) { input -> RACSignal<Output> in
 			return self.apply(Input(reconstructing: input)).bridged
 		}
 	}
@@ -494,7 +494,7 @@ extension Action where Input: AnyObject, Output: OptionalProtocol, Output.Wrappe
 	///         when the action is. However, the reverse is always true: the Action
 	///         will always be marked as executing when the `RACCommand` is.
 	public var bridged: RACCommand<Input, Output.Wrapped> {
-		return RACCommand<Input, Output.Wrapped>(enabled: isEnabled) { input -> RACSignal<Output.Wrapped> in
+		return RACCommand<Input, Output.Wrapped>(enabled: isEnabledSignal) { input -> RACSignal<Output.Wrapped> in
 			return self.apply(input!).bridged
 		}
 	}
@@ -510,7 +510,7 @@ extension Action where Input: OptionalProtocol, Input.Wrapped: AnyObject, Output
 	///         when the action is. However, the reverse is always true: the Action
 	///         will always be marked as executing when the RACCommand is.
 	public var bridged: RACCommand<Input.Wrapped, Output.Wrapped> {
-		return RACCommand<Input.Wrapped, Output.Wrapped>(enabled: isEnabled) { input -> RACSignal<Output.Wrapped> in
+		return RACCommand<Input.Wrapped, Output.Wrapped>(enabled: isEnabledSignal) { input -> RACSignal<Output.Wrapped> in
 			return self.apply(Input(reconstructing: input)).bridged
 		}
 	}


### PR DESCRIPTION
The main fix was a case where we were overloading a computed property based on
return type, which no longer works in Swift 4.2