### PR TITLE
Release 6.0.0

### DIFF
--- a/ReactiveObjCBridge.podspec
+++ b/ReactiveObjCBridge.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.module_map = 'ReactiveObjCBridge/module.modulemap'
 
   s.dependency 'ReactiveObjC', '~> 3.1'
-  s.dependency 'ReactiveSwift', '~> 6.0'
+  s.dependency 'ReactiveSwift', '~> 6.1'
 
   s.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS[config=Release]" => "$(inherited) -suppress-warnings" }
 

--- a/ReactiveObjCBridge/Info.plist
+++ b/ReactiveObjCBridge/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.0</string>
+	<string>6.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Refs:
- #58 
- #60 
- #61 

---

ReactiveObjCBridge 6.0 bumps ReactiveSwift dependency to 6.1.